### PR TITLE
Stick Fog dependency to version 1.24 to prevent AWS Regions issue

### DIFF
--- a/lib/sluice/version.rb
+++ b/lib/sluice/version.rb
@@ -15,5 +15,5 @@
 
 module Sluice
   NAME    = "sluice"
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/sluice.gemspec
+++ b/sluice.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.add_dependency 'contracts', '~> 0.4'
-  gem.add_dependency 'fog', '~> 1.22'
+  gem.add_dependency 'fog', '1.24'
 
   gem.add_development_dependency "rspec", "~> 2.14", ">= 2.14.1"
   gem.add_development_dependency "rspec-nc"


### PR DESCRIPTION
Closes #32

Integration of Fog >=1.25 require attention and adaptation in Sluice to
prevent AWS Region Issues. More Information on Fog repo:
https://github.com/fog/fog/issues/3275